### PR TITLE
Bugfix/opposite-keys: Fix movement bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "y",
+  "name": "MissIt-canvas",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/hero.js
+++ b/src/hero.js
@@ -40,15 +40,34 @@ class Hero extends Square {
   }
 
   resetMovementAxis(e) {
-    this.keysPressed[e.keyCode] = true;
-    if (e.keyCode === Keyboard.LEFT || e.keyCode === Keyboard.RIGHT) {
-      this.movement.x = 0;
-    } else if (e.keyCode === Keyboard.DOWN || e.keyCode === Keyboard.UP) {
-      this.movement.y = 0;
-    }
-
-    for (key in this.keysPressed) {
-      if ()
+    this.keysPressed[e.keyCode] = false;
+    switch(e.keyCode) {
+      case Keyboard.DOWN:
+        this.movement.y = 0;
+        if (this.keysPressed[Keyboard.UP]) {
+          this.setMovementAxis({keyCode: Keyboard.UP})
+        }
+        break;
+      case Keyboard.UP:
+        this.movement.y = 0;
+        if (this.keysPressed[Keyboard.DOWN]) {
+          this.setMovementAxis({keyCode: Keyboard.DOWN})
+        }
+        break;
+      case Keyboard.LEFT:
+        this.movement.x = 0;
+        if (this.keysPressed[Keyboard.RIGHT]) {
+          this.setMovementAxis({keyCode: Keyboard.RIGHT})
+        }
+        break;
+      case Keyboard.RIGHT:
+        this.movement.x = 0;
+        if (this.keysPressed[Keyboard.LEFT]) {
+          this.setMovementAxis({keyCode: Keyboard.LEFT})
+        }
+        break;
+      default:
+        break;
     }
   }
 

--- a/src/hero.js
+++ b/src/hero.js
@@ -9,65 +9,45 @@ class Hero extends Square {
     this.movement = {
       x: 0, y: 0
     };
-    this.keysPressed = {
-      [Keyboard.DOWN]: false,
-      [Keyboard.UP]: false,
-      [Keyboard.LEFT]: false,
-      [Keyboard.RIGHT]: false
+    this.keys = {
+      [Keyboard.DOWN]: {
+        isPressed: false, 
+        opposite: Keyboard.UP, 
+        movement: {axis: 'y', direction: 1}
+      },
+      [Keyboard.UP]: {
+        isPressed: false, 
+        opposite: Keyboard.DOWN, 
+        movement: {axis: 'y', direction: -1}
+      },
+      [Keyboard.LEFT]: {
+        isPressed: false, 
+        opposite: Keyboard.RIGHT, 
+        movement: {axis: 'x', direction: -1}
+      },
+      [Keyboard.RIGHT]: {
+        isPressed: false, 
+        opposite: Keyboard.LEFT, 
+        movement: {axis: 'x', direction: 1}
+      },
     };
     window.addEventListener('keydown', this.setMovementAxis);
     window.addEventListener('keyup', this.resetMovementAxis);
   }
 
   setMovementAxis(e) {
-    this.keysPressed[e.keyCode] = true;
-    switch(e.keyCode) {
-      case Keyboard.DOWN:
-        this.movement.y = 1;
-        break;
-      case Keyboard.UP:
-        this.movement.y = -1;
-        break;
-      case Keyboard.LEFT:
-        this.movement.x = -1;
-        break;
-      case Keyboard.RIGHT:
-        this.movement.x = 1;
-        break;
-      default:
-        break;
-    }
+    const key = this.keys[e.keyCode];
+    key.isPressed = true;
+    this.movement[key.movement.axis] = key.movement.direction;
   }
 
   resetMovementAxis(e) {
-    this.keysPressed[e.keyCode] = false;
-    switch(e.keyCode) {
-      case Keyboard.DOWN:
-        this.movement.y = 0;
-        if (this.keysPressed[Keyboard.UP]) {
-          this.setMovementAxis({keyCode: Keyboard.UP})
-        }
-        break;
-      case Keyboard.UP:
-        this.movement.y = 0;
-        if (this.keysPressed[Keyboard.DOWN]) {
-          this.setMovementAxis({keyCode: Keyboard.DOWN})
-        }
-        break;
-      case Keyboard.LEFT:
-        this.movement.x = 0;
-        if (this.keysPressed[Keyboard.RIGHT]) {
-          this.setMovementAxis({keyCode: Keyboard.RIGHT})
-        }
-        break;
-      case Keyboard.RIGHT:
-        this.movement.x = 0;
-        if (this.keysPressed[Keyboard.LEFT]) {
-          this.setMovementAxis({keyCode: Keyboard.LEFT})
-        }
-        break;
-      default:
-        break;
+    const key = this.keys[e.keyCode];
+    key.isPressed = false;
+    if (this.keys[key.opposite].isPressed) {
+      this.setMovementAxis({keyCode: key.opposite});
+    } else {
+      this.movement[key.movement.axis] = 0;
     }
   }
 

--- a/src/hero.js
+++ b/src/hero.js
@@ -9,11 +9,18 @@ class Hero extends Square {
     this.movement = {
       x: 0, y: 0
     };
+    this.keysPressed = {
+      [Keyboard.DOWN]: false,
+      [Keyboard.UP]: false,
+      [Keyboard.LEFT]: false,
+      [Keyboard.RIGHT]: false
+    };
     window.addEventListener('keydown', this.setMovementAxis);
     window.addEventListener('keyup', this.resetMovementAxis);
   }
 
   setMovementAxis(e) {
+    this.keysPressed[e.keyCode] = true;
     switch(e.keyCode) {
       case Keyboard.DOWN:
         this.movement.y = 1;
@@ -33,10 +40,15 @@ class Hero extends Square {
   }
 
   resetMovementAxis(e) {
+    this.keysPressed[e.keyCode] = true;
     if (e.keyCode === Keyboard.LEFT || e.keyCode === Keyboard.RIGHT) {
       this.movement.x = 0;
     } else if (e.keyCode === Keyboard.DOWN || e.keyCode === Keyboard.UP) {
       this.movement.y = 0;
+    }
+
+    for (key in this.keysPressed) {
+      if ()
     }
   }
 


### PR DESCRIPTION
I also took the opportunity to make the code more declarative.

The movement bug was the following: 

- User press the LEFT key
Character starts moving to the left.
- User then  press the RIGHT key WITHOUT RELEASING the LEFT key
Character starts moving to the right.
- User then releases the RIGHT key. now the user is holding only the LEFT key
 Character stops moving. <- There is the bug. the character should started moving to the left.

To fix this, I started keep tracking of all pressed keys instead of only caring about the last pressed key.
Then, once the user releases a key, I check if the opposite key is being pressed atm. if not, the character can stop moving. if yes, the character starts moving into the opposite direction.

